### PR TITLE
Ensure tests import config correctly

### DIFF
--- a/InterviewAgent/src/core/exceptions.py
+++ b/InterviewAgent/src/core/exceptions.py
@@ -30,6 +30,11 @@ class InterviewAgentException(Exception):
             "cause": str(self.cause) if self.cause else None
         }
 
+
+class BaseInterviewAgentError(InterviewAgentException):
+    """Backward-compatible base exception alias."""
+    pass
+
 class ConfigurationError(InterviewAgentException):
     """Configuration-related errors"""
     pass

--- a/InterviewAgent/tests/test_app.py
+++ b/InterviewAgent/tests/test_app.py
@@ -5,7 +5,7 @@ Simple test script to verify InterviewAgent components
 
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 def test_imports():
     """Test that all modules can be imported"""


### PR DESCRIPTION
## Summary
- add project's src path to test helper
- define BaseInterviewAgentError alias used by imports

## Testing
- `pytest tests/test_app.py::test_imports -q`


------
https://chatgpt.com/codex/tasks/task_e_6894589b3fd48327829abc1011f85284