### PR TITLE
Document test status across agent projects

### DIFF
--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,0 +1,13 @@
+# Test Results for Agents
+
+| Agent Project | Test Command | Result |
+|---------------|--------------|--------|
+| Azure DevOps MCP | N/A | No tests discovered |
+| CoachAI | `pytest` | No tests ran |
+| Project Starlink | `pytest` | No tests ran |
+| ClaudeCode | `npm test` | Error: no test specified |
+| InterviewAgent | `pytest` | Failed: ModuleNotFoundError: No module named 'supabase'; dependency installation failed (smtplib2 not found) |
+| ai_agent_project | `pytest` | Failed: ImportError: attempted relative import with no known parent package |
+| windsurf-demo | `pytest` | No tests ran |
+
+Generated on Mon Aug 11 04:58:11 UTC 2025


### PR DESCRIPTION
## Summary
- record test outcomes for each agent subproject

## Testing
- `pytest` in Azure DevOps MCP
- `pytest` in CoachAI
- `pytest` in Project Starlink
- `npm test` in ClaudeCode
- `pip install -r requirements.txt` in InterviewAgent *(fails: smtplib2 not found)*
- `pytest` in InterviewAgent *(fails: ModuleNotFoundError: No module named 'supabase')*
- `pytest` in ai_agent_project *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest` in windsurf-demo


------
https://chatgpt.com/codex/tasks/task_e_68997786a870832786f001a93bb02fc7